### PR TITLE
Removing redundant threadpool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,6 +747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "pixelpwnr-render"
 version = "0.1.0"
+source = "git+https://github.com/timvisee/pixelpwnr-render.git#1f3fbcd5fb1d228e62c36396fce83207f653dd9f"
 dependencies = [
  "gfx 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx_device_gl 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -770,7 +771,7 @@ dependencies = [
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "number_prefix 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "pixelpwnr-render 0.1.0",
+ "pixelpwnr-render 0.1.0 (git+https://github.com/timvisee/pixelpwnr-render.git)",
  "serde 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1354,6 +1355,7 @@ dependencies = [
 "checksum objc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "877f30f37acef6749b1841cceab289707f211aecfc756553cd63976190e6cc2e"
 "checksum osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "88cfece6e95d2e717e0872a7f53a8684712ad13822a7979bc760b9c77ec0013b"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
+"checksum pixelpwnr-render 0.1.0 (git+https://github.com/timvisee/pixelpwnr-render.git)" = "<none>"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
 "checksum png 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f0b0cabbbd20c2d7f06dbf015e06aad59b6ca3d9ed14848783e98af9aaf19925"
 "checksum proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cd07deb3c6d1d9ff827999c7f9b04cdfd66b1b17ae508e14fe47b620f2282ae0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,26 +22,26 @@ mod arg_handler;
 mod client;
 mod cmd;
 mod codec;
-mod stats;
 mod stat_monitor;
 mod stat_reporter;
+mod stats;
 
 use std::sync::Arc;
 use std::thread;
 
-use futures::prelude::*;
 use futures::future::Executor;
+use futures::prelude::*;
 use futures::sync::mpsc;
 use futures_cpupool::Builder;
 use pixelpwnr_render::{Pixmap, Renderer};
-use tokio::net::{TcpStream, TcpListener};
+use tokio::net::{TcpListener, TcpStream};
 
 use app::APP_NAME;
 use arg_handler::ArgHandler;
 use client::Client;
 use codec::Lines;
-use stats::{Stats, StatsRaw};
 use stat_reporter::StatReporter;
+use stats::{Stats, StatsRaw};
 
 // TODO: use some constant for new lines
 
@@ -69,30 +69,19 @@ fn main() {
     let stats_thread = stats.clone();
     let host = arg_handler.host();
     let server_thread = thread::spawn(move || {
-        // Second argument, the number of threads we'll be using
-        let num_threads = num_cpus::get();
-
         let listener = TcpListener::bind(&host).expect("failed to bind");
         println!("Listening on: {}", host);
 
-        // Spin up our worker threads, creating a channel routing to each worker
-        // thread that we'll use below.
-        let mut channels = Vec::new();
-        for _ in 0..num_threads {
-            let (tx, rx) = mpsc::unbounded();
-            channels.push(tx);
-            let pixmap_worker = pixmap_thread.clone();
-            let stats_worker = stats_thread.clone();
-            thread::spawn(|| worker(rx, pixmap_worker, stats_worker));
-        }
+        // Create a worker thread that assigns work to a futures threadpool
+        let (tx, rx) = mpsc::unbounded();
+        let pixmap_worker = pixmap_thread.clone();
+        let stats_worker = stats_thread.clone();
+        thread::spawn(|| worker(rx, pixmap_worker, stats_worker));
 
-        // Infinitely accept sockets from our `TcpListener`. Each socket is then
-        // shipped round-robin to a particular thread which will associate the
-        // socket with the corresponding event loop and process the connection.
-        let mut next = 0;
+        // Infinitely accept sockets from our `TcpListener`.
+        // Send work to the worker
         let srv = listener.incoming().for_each(|socket| {
-            channels[next].unbounded_send(socket).expect("worker thread died");
-            next = (next + 1) % channels.len();
+            tx.unbounded_send(socket).expect("worker thread died");
             Ok(())
         });
 
@@ -109,15 +98,10 @@ fn main() {
     }
 }
 
-fn worker(
-    rx: mpsc::UnboundedReceiver<TcpStream>,
-    pixmap: Arc<Pixmap>,
-    stats: Arc<Stats>,
-) {
-    // Build a CPU pool
-    // TODO: share a CPU pool across all workers
+fn worker(rx: mpsc::UnboundedReceiver<TcpStream>, pixmap: Arc<Pixmap>, stats: Arc<Stats>) {
+    let num_threads = num_cpus::get();
     let pool = Builder::new()
-        .pool_size(8)
+        .pool_size(num_threads)
         .name_prefix(format!("{}-worker", APP_NAME))
         .create();
 
@@ -174,7 +158,7 @@ fn render(arg_handler: &ArgHandler, pixmap: &Pixmap, stats: Arc<Stats>) {
         arg_handler.stats_stdout_interval(),
         arg_handler.stats_save_interval(),
         arg_handler.stats_file(),
-        stats, 
+        stats,
         Some(stats_text),
     );
     reporter.start();


### PR DESCRIPTION
This fixes #2 :slightly_smiling_face:  Maybe not the nicest way of implementing it but it doesn't touch a lot of code (which is nice).

This should however be tested at length, as I can't actually get the renderer to run. It crashes immediately on my system with

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: OpenGlVersionNotSupported', libcore/result.rs:945:5
```

(Actually, if you have an idea about that, let me know :sweat_smile:)