### PR TITLE
Ratelimit

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ cargo build --release
 ```
 ## The binary PX command
 
-This implementation adds a new command to the protocol. It is enabled if the `--binary` flag is passed to `pixelflut-server` when
-running the exectuable.
+This implementation adds a new command to the protocol. 
+
+This type of command is enabled by default, but can be disabled by passing the `--no-binary` flag to `pixelflut-server` when running the exectuable.
 
 The command is laid out as follows:
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,11 @@ cargo build --release
 ./target/release/pixelpwnr-server --help
 ```
 ## The binary PX command
-This implementation adds a new command to the protocol, which is laid out as follows:
+
+This implementation adds a new command to the protocol. It is enabled if the `--binary` flag is passed to `pixelflut-server` when
+running the exectuable.
+
+The command is laid out as follows:
 
 ```
 PBxyrgba
@@ -58,8 +62,6 @@ where:
 * `x` and `y` are Little-Endian u16 values describing the X and Y coordinate of the pixel to set.
 * `r`, `g`, `b` and `a` are single-byte values describing the R, G, B, and A components of the color to set the pixel to.
 * It is important to note that this command does _not_ end in a newline. Appending a newline simply causes the server to interpret that newline as an empty command (which is fine).
-
-If you wish to disable the binary pixel command, pass the `--no-default-features` flag to `cargo`
 
 ## Requirements
 * Rust (MSRV v1.58.1 or higher)

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -31,8 +31,7 @@ parking_lot = "0.12.0"
 image = { version = "0.24", default-features = false, features = [ "png" ] }
 
 [features]
-binary-pixel-cmd = []
-default = ["binary-pixel-cmd"]
+default = [ ]
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/server/src/arg_handler.rs
+++ b/server/src/arg_handler.rs
@@ -80,9 +80,9 @@ pub struct Opts {
     #[clap(long)]
     pub bw_limit: Option<usize>,
 
-    /// Enable binary commands
+    /// Disable binary commands
     #[clap(long)]
-    pub binary: bool,
+    pub no_binary: bool,
 }
 
 macro_rules! map_duration {
@@ -143,7 +143,7 @@ impl From<Opts> for CodecOptions {
             rate_limit: opts
                 .bw_limit
                 .map(|bps| RateLimit::BitsPerSecond { limit: bps }),
-            allow_binary_cmd: opts.binary,
+            allow_binary_cmd: !opts.no_binary,
         }
     }
 }

--- a/server/src/arg_handler.rs
+++ b/server/src/arg_handler.rs
@@ -6,7 +6,7 @@ use clap::Parser;
 
 use crate::codec::{CodecOptions, RateLimit};
 
-#[derive(Parser)]
+#[derive(Parser, Clone)]
 pub struct Opts {
     /// The host to bind to
     #[clap(long, default_value = "0.0.0.0:1337", alias = "bind")]

--- a/server/src/arg_handler.rs
+++ b/server/src/arg_handler.rs
@@ -4,6 +4,8 @@ use std::time::Duration;
 
 use clap::Parser;
 
+use crate::codec::{CodecOptions, RateLimit};
+
 #[derive(Parser)]
 pub struct Opts {
     /// The host to bind to
@@ -72,6 +74,11 @@ pub struct Opts {
     /// This value is only relevant if --save-dir is specified
     #[clap(long, default_value = "60")]
     pub save_interval: u64,
+
+    /// The maximum bandwidth at which a single client is
+    /// allowed to send data to the server, in bits per second. Default is unlimited.
+    #[clap(long)]
+    pub bw_limit: Option<usize>,
 }
 
 macro_rules! map_duration {
@@ -123,5 +130,15 @@ impl Opts {
                 .parse()
                 .expect("Invalid Y offset for stats"),
         )
+    }
+}
+
+impl From<Opts> for CodecOptions {
+    fn from(opts: Opts) -> Self {
+        CodecOptions {
+            rate_limit: opts
+                .bw_limit
+                .map(|bps| RateLimit::BitsPerSecond { limit: bps }),
+        }
     }
 }

--- a/server/src/arg_handler.rs
+++ b/server/src/arg_handler.rs
@@ -79,6 +79,10 @@ pub struct Opts {
     /// allowed to send data to the server, in bits per second. Default is unlimited.
     #[clap(long)]
     pub bw_limit: Option<usize>,
+
+    /// Enable binary commands
+    #[clap(long)]
+    pub binary: bool,
 }
 
 macro_rules! map_duration {
@@ -139,6 +143,7 @@ impl From<Opts> for CodecOptions {
             rate_limit: opts
                 .bw_limit
                 .map(|bps| RateLimit::BitsPerSecond { limit: bps }),
+            allow_binary_cmd: opts.binary,
         }
     }
 }

--- a/server/src/cmd.rs
+++ b/server/src/cmd.rs
@@ -2,7 +2,7 @@ use atoi::atoi;
 use bytes::Bytes;
 use pixelpwnr_render::{Color, Pixmap, PixmapErr};
 
-use crate::codec::CodecOptions;
+use crate::codec::{CodecOptions, RateLimit};
 
 /// A set of pixel commands a client might send.
 ///
@@ -163,7 +163,14 @@ impl Cmd {
             );
         }
 
-        help.push_str("            \r\nHELP - QUIT         >> (Disconnect)\r\n");
+        help.push_str("            \r\nHELP - QUIT         >> (Disconnect)");
+
+        if let Some(RateLimit::BitsPerSecond { limit }) = opts.rate_limit {
+            help.push_str(&format!(
+                "\r\nHELP - Input from a single client is limited to {} bits per second",
+                limit
+            ));
+        }
 
         help
     }

--- a/server/src/codec.rs
+++ b/server/src/codec.rs
@@ -11,6 +11,18 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use crate::cmd::{Cmd, CmdResult};
 use crate::stats::Stats;
 
+#[derive(Debug, Clone, Copy)]
+pub struct CodecOptions {
+    pub rate_limit: Option<RateLimit>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum RateLimit {
+    // A rate limit in bits per second
+    BitsPerSecond { limit: usize },
+    // Pixels { pps: usize },
+}
+
 /// The capacity of the read and write buffer in bytes.
 const BUF_SIZE: usize = 64_000;
 

--- a/server/src/codec/mod.rs
+++ b/server/src/codec/mod.rs
@@ -19,6 +19,7 @@ mod test;
 #[derive(Debug, Clone, Copy)]
 pub struct CodecOptions {
     pub rate_limit: Option<RateLimit>,
+    pub allow_binary_cmd: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -231,7 +232,7 @@ where
         let error_message = loop {
             let rd_len = self.rd.len();
 
-            let is_binary_command = cfg!(feature = "binary-pixel-cmd")
+            let is_binary_command = self.opts.allow_binary_cmd
                 && rd_len >= PXB_PREFIX.len()
                 && &self.rd[..PXB_PREFIX.len()] == PXB_PREFIX;
 
@@ -299,7 +300,7 @@ where
                 break None;
             };
 
-            let result = command.invoke(&self.pixmap, &mut pixels);
+            let result = command.invoke(&self.pixmap, &mut pixels, &self.opts);
             // Do something with the result
             match result {
                 // Do nothing

--- a/server/src/codec/test.rs
+++ b/server/src/codec/test.rs
@@ -1,0 +1,34 @@
+use super::*;
+
+const CODEC_OPTS: CodecOptions = CodecOptions { rate_limit: None };
+
+#[tokio::test]
+async fn response_newline() {
+    let stats = Arc::new(Stats::new());
+    let pixmap = Arc::new(Pixmap::new(400, 800));
+
+    let mut test = tokio_test::io::Builder::new()
+        // Test all commands that require a response
+        .read(b"PX 16 16\r\n")
+        .write(b"PX 16 16 000000\r\n")
+        .read(b"SIZE\r\n")
+        .write(b"SIZE 400 800\r\n")
+        .read(b"HELP\r\n")
+        .write(format!("{}\r\n", Cmd::help_list()).as_bytes())
+        // Test different variations of newlines
+        .read(b"PX 16 16\n")
+        .write(b"PX 16 16 000000\r\n")
+        // Verify that adding a few whitespaces after the command doesn't make a difference
+        .read(b"PX 16 16                     \n")
+        .write(b"PX 16 16 000000\r\n")
+        // Using an out of bounds index should return an error
+        .read(b"PX 1000 0\r\n")
+        .write(b"ERR x coordinate out of bound\r\n")
+        .build();
+
+    let test = Pin::new(&mut test);
+
+    let lines = Lines::new(test, stats.clone(), pixmap.clone(), CODEC_OPTS);
+
+    lines.await;
+}

--- a/server/src/codec/test.rs
+++ b/server/src/codec/test.rs
@@ -1,6 +1,9 @@
 use super::*;
 
-const CODEC_OPTS: CodecOptions = CodecOptions { rate_limit: None };
+const CODEC_OPTS: CodecOptions = CodecOptions {
+    rate_limit: None,
+    allow_binary_cmd: true,
+};
 
 #[tokio::test]
 async fn response_newline() {
@@ -14,7 +17,7 @@ async fn response_newline() {
         .read(b"SIZE\r\n")
         .write(b"SIZE 400 800\r\n")
         .read(b"HELP\r\n")
-        .write(format!("{}\r\n", Cmd::help_list()).as_bytes())
+        .write(format!("{}\r\n", Cmd::help_list(&CODEC_OPTS)).as_bytes())
         // Test different variations of newlines
         .read(b"PX 16 16\n")
         .write(b"PX 16 16 000000\r\n")

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -19,7 +19,7 @@ use clap::StructOpt;
 use pixelpwnr_render::{Pixmap, Renderer};
 use tokio::net::{TcpListener, TcpStream};
 
-use codec::Lines;
+use codec::{CodecOptions, Lines};
 use stat_reporter::StatReporter;
 use stats::{Stats, StatsRaw};
 
@@ -76,9 +76,10 @@ fn main() {
     let net_pixmap = pixmap.clone();
     let net_stats = stats.clone();
     let net_running_2 = net_running.clone();
+    let opts = arg_handler.clone().into();
     let tokio_runtime = std::thread::spawn(move || {
         runtime.block_on(async move {
-            listen(listener, net_pixmap, net_stats).await;
+            listen(listener, net_pixmap, net_stats, opts).await;
             net_running_2.store(false, Ordering::Relaxed);
         })
     });
@@ -90,7 +91,12 @@ fn main() {
     }
 }
 
-async fn listen(listener: std::net::TcpListener, pixmap: Arc<Pixmap>, stats: Arc<Stats>) {
+async fn listen(
+    listener: std::net::TcpListener,
+    pixmap: Arc<Pixmap>,
+    stats: Arc<Stats>,
+    opts: CodecOptions,
+) {
     let listener = TcpListener::from_std(listener).unwrap();
 
     loop {
@@ -102,7 +108,7 @@ async fn listen(listener: std::net::TcpListener, pixmap: Arc<Pixmap>, stats: Arc
             println!("Failed to accept a connection");
             continue;
         };
-        handle_socket(socket, pixmap_worker, stats_worker);
+        handle_socket(socket, pixmap_worker, stats_worker, opts);
     }
 }
 
@@ -136,7 +142,12 @@ async fn spawn_save_image(dir: PathBuf, pixmap: Arc<Pixmap>, interval: Duration)
 }
 
 /// Spawn a new task with the given socket
-fn handle_socket(mut socket: TcpStream, pixmap: Arc<Pixmap>, stats: Arc<Stats>) {
+fn handle_socket(
+    mut socket: TcpStream,
+    pixmap: Arc<Pixmap>,
+    stats: Arc<Stats>,
+    opts: CodecOptions,
+) {
     // A client connected, ensure we're able to get it's address
     let addr = socket.peer_addr().expect("failed to get remote address");
     println!("A client connected (from: {})", addr);
@@ -154,7 +165,7 @@ fn handle_socket(mut socket: TcpStream, pixmap: Arc<Pixmap>, stats: Arc<Stats>) 
 
         // Wrap the socket with the Lines codec,
         // to interact with lines instead of raw bytes
-        let mut lines_val = Lines::new(socket, stats.clone(), pixmap);
+        let mut lines_val = Lines::new(socket, stats.clone(), pixmap, opts);
         let lines = Pin::new(&mut lines_val);
 
         let result = lines.await;


### PR DESCRIPTION
Adds a per-client rate limit

Switch the binary pixel command from being a compile time flag to being a flag that can be passed to the exectuable.