### PR TITLE
Avoid Server crash in case of immediate disconnect

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -150,7 +150,13 @@ fn handle_socket(
     opts: CodecOptions,
 ) {
     // A client connected, ensure we're able to get it's address
-    let addr = socket.peer_addr().expect("failed to get remote address");
+   let addr = match socket.peer_addr() {
+        Ok(addr) => addr,
+        Err(err) => {
+            eprintln!("Failed to get remote address: {}", err);
+            return; // Terminate the function gracefully
+        }
+    };
     println!("A client connected (from: {})", addr);
 
     // Increase the number of clients


### PR DESCRIPTION
Fix issue where badly behaving client can easily make the server crash.


Reproducible on Mac Pro m1 running server and then executing the following on the bash a few times:

`echo 'PX 100 100 ff8000' -0 | netcat localhost 1337 -z`

The quick disconnect here because of the -z causes the exceptional case to be triggered.